### PR TITLE
Remove DESI_IMAGING_DATA

### DIFF
--- a/etc/desitree.module
+++ b/etc/desitree.module
@@ -79,7 +79,6 @@ setenv [string toupper $product] $PRODUCT_DIR
 if {{[info exists env(NERSC_HOST)]}} {{
     set desi_root /global/project/projectdirs/desi
     setenv DESI_ROOT $desi_root
-    setenv DESI_IMAGING_DATA $desi_root/imaging/data
     setenv DESI_MOCKS $desi_root/mocks
     setenv DESI_SPECTRO_DATA $desi_root/spectro/data
     setenv DESI_SPECTRO_REDUX $desi_root/spectro/redux


### PR DESCRIPTION
The physical directory that `DESI_IMAGING_DATA` points to has already been removed from NERSC.