### PR TITLE
Assume DESI_ROOT is external

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,5 +2,52 @@
 desitree
 ========
 
+Introduction
+------------
+
 This product is used to maintain the DESI directory hierarchy and to map
 directories to environment variables.
+
+Change Log
+-----------
+
+0.6.0 (unreleased)
+~~~~~~~~~~~~~~~~~~
+
+* Define ``${DESI_ROOT}`` external to this module file for compatibility with
+  Lmod_ and Perlmutter_ (PR `#7`_).
+
+.. _`#7`: https://github.com/desihub/desitree/pull/7
+.. _Lmod: https://lmod.readthedocs.io/en/latest/
+.. _Perlmutter: https://www.nersc.gov/systems/perlmutter/
+
+0.5.0 (2020-01-19)
+~~~~~~~~~~~~~~~~~~
+
+* Migrate ``/global/project/projectdirs`` to ``/global/cfs/cdirs``.
+
+0.4.0 (2019-04-02)
+~~~~~~~~~~~~~~~~~~
+
+* Remove unused ``${DESI_IMAGING_DATA}`` (PR `#5`_).
+
+.. _`#5`: https://github.com/desihub/desitree/pull/5
+
+0.3.0 (2016-10-12)
+~~~~~~~~~~~~~~~~~~
+
+* Update based on desiconda migration (PR `#3`_).
+
+.. _`#3`: https://github.com/desihub/desitree/pull/3
+
+0.2.0 (2015-10-30)
+~~~~~~~~~~~~~~~~~~
+
+* Add additional variables needed for pipeline processing (PR `#1`_).
+
+.. _`#1`: https://github.com/desihub/desitree/pull/1
+
+0.1.0 (2015-10-30)
+~~~~~~~~~~~~~~~~~~
+
+* Reference tag to archive original code.

--- a/etc/desitree.module
+++ b/etc/desitree.module
@@ -76,19 +76,15 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-if {{[info exists env(NERSC_HOST)]}} {{
-    set desi_root /global/cfs/cdirs/desi
-    setenv DESI_ROOT $desi_root
-    setenv DESI_MOCKS $desi_root/mocks
-    setenv DESI_SPECTRO_DATA $desi_root/spectro/data
-    setenv DESI_SPECTRO_REDUX $desi_root/spectro/redux
-    setenv DESI_SPECTRO_SIM $desi_root/spectro/sim
-    setenv DESI_TARGET $desi_root/target
-    setenv DESI_WWW $desi_root/www
+if {{[info exists env(DESI_ROOT)]}} {{
+    set root $env(DESI_ROOT)
+    setenv DESI_MOCKS $root/mocks
+    setenv DESI_SPECTRO_DATA $root/spectro/data
+    setenv DESI_SPECTRO_REDUX $root/spectro/redux
+    setenv DESI_SPECTRO_SIM $root/spectro/sim
+    setenv DESI_TARGET $root/target
+    setenv DESI_WWW $root/www
     setenv PIXPROD $env(USER)
     setenv SPECPROD $env(USER)
     setenv PRODNAME $env(USER)
 }}
-#
-# Handle non-NERSC setups
-#

--- a/etc/desitree.module
+++ b/etc/desitree.module
@@ -82,6 +82,7 @@ if {{[info exists env(DESI_ROOT)]}} {{
     setenv DESI_SPECTRO_DATA $root/spectro/data
     setenv DESI_SPECTRO_REDUX $root/spectro/redux
     setenv DESI_SPECTRO_SIM $root/spectro/sim
+    setenv DESI_SURVEYOPS $root/survey/ops/surveyops/trunk
     setenv DESI_TARGET $root/target
     setenv DESI_WWW $root/www
     setenv PIXPROD $env(USER)


### PR DESCRIPTION
This PR fixes #6 by not defining `DESI_ROOT` within the module itself.  As a side-effect it allows this module to work anywhere that `DESI_ROOT` is defined, not just NERSC.

As far as I can tell, desitree is never used in a main/master checkout, but only as a tag, so we can go ahead and merge and tag this, then later incorporate the latest tag into a desimodules update.