### PR TITLE
Remove DESI_SURVEYOPS

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2020, DESI Collaboration <desi-data@desi.lbl.gov>
+Copyright (c) 2014-2024, DESI Collaboration <desi-data@desi.lbl.gov>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,13 @@ directories to environment variables.
 Change Log
 -----------
 
+0.7.0 (2024-07-19)
+~~~~~~~~~~~~~~~~~~
+
+* Remove ``DESI_SURVEYOPS``, which will now be defined by ``desimodules`` (PR `#9`_).
+
+.. _`#9`: https://github.com/desihub/desitree/pull/9
+
 0.6.0 (2021-11-03)
 ~~~~~~~~~~~~~~~~~~
 

--- a/etc/desitree.module
+++ b/etc/desitree.module
@@ -82,7 +82,6 @@ if {{[info exists env(DESI_ROOT)]}} {{
     setenv DESI_SPECTRO_DATA $root/spectro/data
     setenv DESI_SPECTRO_REDUX $root/spectro/redux
     setenv DESI_SPECTRO_SIM $root/spectro/sim
-    setenv DESI_SURVEYOPS $root/survey/ops/surveyops/trunk
     setenv DESI_TARGET $root/target
     setenv DESI_WWW $root/www
     setenv PIXPROD $env(USER)


### PR DESCRIPTION
`DESI_SURVEYOPS` will be defined in `desimodules` going forward, see desihub/desimodules#52. This PR should be merged only after that PR is completed.